### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-vercel-app.yml
+++ b/.github/workflows/deploy-vercel-app.yml
@@ -1,4 +1,6 @@
 name: Vercel Production Deployment
+permissions:
+  contents: read
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
Potential fix for [https://github.com/sebastiankdittmann/homepage/security/code-scanning/1](https://github.com/sebastiankdittmann/homepage/security/code-scanning/1)

In general, to fix this class of issue you add a `permissions:` block either at the root of the workflow (to apply to all jobs) or inside the specific job that needs restricted access, granting only the minimum scopes needed (often `contents: read`). This overrides the repository’s default `GITHUB_TOKEN` permissions so the workflow cannot perform unintended write operations via GitHub’s API.

For this specific workflow, none of the steps require write access to the repository or to issues/PRs; they use `actions/checkout`, `setup-node`, `npm`, and `vercel` with a separate `VERCEL_TOKEN` secret. The minimal safe permission is therefore `contents: read`. The best fix, without changing functionality, is to add a root-level `permissions:` block directly under the `name:` line (before `env:`) with `contents: read`. This will apply to the `Deploy-Production` job and any future jobs unless they override it. No imports or additional definitions are required; this is a pure YAML configuration change within `.github/workflows/deploy-vercel-app.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
